### PR TITLE
Allow hackily setting users' colors on the client 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Dankerino
 
+- Minor: Added support for setting chat colors locally (Mm2PL/Dankerino#135)
 - Minor: Added support for SupaBridge (Mm2PL/Dankerino#134)
 - Minor: Added a link to the upstream commit (Mm2PL/Dankerino#127)
 - Minor: Added RaccAttack URL to Twitch Emote context menu (Mm2PL/Dankerino#122)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
Set someone's nick to ::hack-set-color color to change what dankerino shows regardless of the reality