### PR TITLE
fix: make 7tv code compile using Qt6

### DIFF
--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -35,6 +35,7 @@
 
 #include <QCheckBox>
 #include <QDesktopServices>
+#include <QFile>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -1094,7 +1094,8 @@ void UserInfoPopup::fetchSevenTVAvatar(const HelixUser &user)
                             auto data = outcome.getData();
                             QCryptographicHash hash(
                                 QCryptographicHash::Algorithm::Sha1);
-                            auto SHA = QString(data.size()).toUtf8();
+                            auto SHA =
+                                QString(static_cast<int>(data.size())).toUtf8();
                             hash.addData(SHA.data(), SHA.size() + 1);
 
                             auto filename =

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -1089,23 +1089,23 @@ void UserInfoPopup::fetchSevenTVAvatar(const HelixUser &user)
 
                 NetworkRequest(URI)
                     .timeout(20000)
-                    .onSuccess(
-                        [=, this](const NetworkResult &outcome) -> Outcome {
-                            auto data = outcome.getData();
-                            QCryptographicHash hash(
-                                QCryptographicHash::Algorithm::Sha1);
-                            auto SHA =
-                                QString(static_cast<int>(data.size())).toUtf8();
-                            hash.addData(SHA.data(), SHA.size() + 1);
+                    .onSuccess([=,
+                                this](const NetworkResult &outcome) -> Outcome {
+                        auto data = outcome.getData();
+                        QCryptographicHash hash(
+                            QCryptographicHash::Algorithm::Sha1);
+                        auto SHA = QString(QChar(static_cast<int>(data.size())))
+                                       .toUtf8();
+                        hash.addData(SHA.data(), SHA.size() + 1);
 
-                            auto filename =
-                                this->getFilename(hash.result().toHex());
+                        auto filename =
+                            this->getFilename(hash.result().toHex());
 
-                            this->saveCacheAvatar(data, filename);
-                            this->setSevenTVAvatar(filename);
+                        this->saveCacheAvatar(data, filename);
+                        this->setSevenTVAvatar(filename);
 
-                            return Success;
-                        })
+                        return Success;
+                    })
                     .execute();
             }
             return Success;


### PR DESCRIPTION
Pull request checklist:

~~- [ ] `CHANGELOG.md` was updated, if applicable~~

# Description

Adds 2 small fixes that made some of the merged chatterino7 code relating to animated pfps no longer compile using Qt6.